### PR TITLE
Stakewalker patch 1.2

### DIFF
--- a/main.py
+++ b/main.py
@@ -151,7 +151,7 @@ async def job_cardapio():
         await app.send_message("@mascdriver", f'Erro no cardapio automatico em Chapeco dia :{date.today().weekday()}'
                                               f'Resul: {result}')
     else:
-        await app.send_message("@computacaouffs", format_cardapio(result['cardapios'][0], 'Chapecó', silent=True))
+        await app.send_message("@computacaouffs", format_cardapio(result['cardapios'][0], 'Chapecó'), silent=True)
 
 
 @app.on_message(filters.command('bus'))


### PR DESCRIPTION
Apenas a função "send_message" recebe o parâmetro "silent=True". 
O erro causado anteriormente foi por que o parâmetro também foi chamado na função "edit_message" (erro meu).